### PR TITLE
typo: Fix source.id since `source` itself is the ID

### DIFF
--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -745,7 +745,7 @@ const connector = (params) => {
   }
   
   return {
-    id: `edge-${params.source.id}-${params.target}`,
+    id: `edge-${params.source}-${params.target}`,
     source: params.source,
     target: params.target,
     label: `Edge ${params.source}-${params.target}`,


### PR DESCRIPTION
# 🚀 What's changed?

- Fix typo in docs

# 🐛 Fixes

- Fix typo in docs

# 🪴 To-Dos

- No To-Dos